### PR TITLE
fix: DBデータ取得時の文字化け対策を実装

### DIFF
--- a/src/config/database.php
+++ b/src/config/database.php
@@ -10,8 +10,17 @@ class DatabaseConfig {
     public static function getConnection() {
         try {
             $dsn = "mysql:host=" . self::HOST . ";dbname=" . self::DBNAME . ";charset=" . self::CHARSET;
-            $pdo = new PDO($dsn, self::USER, self::PASS);
-            $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+            $pdo = new PDO($dsn, self::USER, self::PASS, [
+                PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                PDO::MYSQL_ATTR_INIT_COMMAND => "SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci"
+            ]);
+            
+            // 文字エンコーディングを確実に設定
+            $pdo->exec("SET NAMES utf8mb4 COLLATE utf8mb4_unicode_ci");
+            $pdo->exec("SET CHARACTER SET utf8mb4");
+            $pdo->exec("SET character_set_connection=utf8mb4");
+            
             return $pdo;
         } catch (PDOException $e) {
             throw new Exception("データベース接続失敗: " . $e->getMessage());

--- a/src/models/Product.php
+++ b/src/models/Product.php
@@ -8,6 +8,19 @@ class Product {
         $this->pdo = DatabaseConfig::getConnection();
     }
     
+    // 文字エンコーディングを正規化するメソッド
+    private function normalizeEncoding($data) {
+        if (is_array($data)) {
+            foreach ($data as $key => $value) {
+                $data[$key] = $this->normalizeEncoding($value);
+            }
+        } elseif (is_string($data)) {
+            // UTF-8として正規化
+            $data = mb_convert_encoding($data, 'UTF-8', 'UTF-8');
+        }
+        return $data;
+    }
+    
     // 商品検索
     public function searchProducts($productName = '', $manufacturerName = '') {
         $sql = "SELECT 
@@ -29,7 +42,8 @@ class Product {
             ':manufacturer_name' => '%' . $manufacturerName . '%'
         ]);
         
-        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $results = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        return $this->normalizeEncoding($results);
     }
     
     // 商品登録
@@ -58,7 +72,8 @@ class Product {
             ':maker' => $manufacturerName
         ]);
         
-        return $stmt->fetch(PDO::FETCH_ASSOC);
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $this->normalizeEncoding($result);
     }
 }
 ?> 

--- a/src/models/Stock.php
+++ b/src/models/Stock.php
@@ -8,6 +8,19 @@ class Stock {
         $this->pdo = DatabaseConfig::getConnection();
     }
     
+    // 文字エンコーディングを正規化するメソッド
+    private function normalizeEncoding($data) {
+        if (is_array($data)) {
+            foreach ($data as $key => $value) {
+                $data[$key] = $this->normalizeEncoding($value);
+            }
+        } elseif (is_string($data)) {
+            // UTF-8として正規化
+            $data = mb_convert_encoding($data, 'UTF-8', 'UTF-8');
+        }
+        return $data;
+    }
+    
     // 在庫登録・更新
     public function upsertStock($productId, $quantity) {
         $sql = "INSERT INTO t_stock (product_id, quantity)

--- a/src/views/inquiry_form.php
+++ b/src/views/inquiry_form.php
@@ -42,8 +42,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 ?>
 
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>商品問い合わせ</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }

--- a/src/views/inventory_search.php
+++ b/src/views/inventory_search.php
@@ -12,8 +12,10 @@ try {
 ?>
 
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>在庫照会</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }

--- a/src/views/upload_csv.php
+++ b/src/views/upload_csv.php
@@ -22,8 +22,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_FILES['csv_file'])) {
 ?>
 
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CSVアップロード</title>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }


### PR DESCRIPTION
## 概要
DBからデータ取得時に発生する文字化けを防ぐための対策を実装しました。

## 変更内容

### データベース接続設定の強化
- PDO接続時に文字エンコーディング設定を追加
- `SET NAMES utf8mb4`コマンドで確実にUTF-8を設定
- `PDO::MYSQL_ATTR_INIT_COMMAND`で初期化コマンドを設定

### モデルクラスでの文字エンコーディング処理
- `Product.php`と`Stock.php`に`normalizeEncoding()`メソッドを追加
- データ取得時にUTF-8として正規化
- 配列と文字列の両方に対応

### HTMLヘッダーの文字エンコーディング設定
- 全ビューファイルに`<meta charset="UTF-8">`を追加
- `lang="ja"`属性も追加
- レスポンシブ対応のviewport設定も追加

## 対象ファイル
- `src/config/database.php`
- `src/models/Product.php`
- `src/models/Stock.php`
- `src/views/inventory_search.php`
- `src/views/upload_csv.php`
- `src/views/inquiry_form.php`

## 技術的な詳細
- **データベース**: `utf8mb4`文字セット（絵文字対応）
- **PHP**: `mb_convert_encoding()`でUTF-8正規化
- **HTML**: UTF-8エンコーディング明示指定
- **PDO**: 接続時に文字エンコーディング設定

## テスト
- 日本語データの取得・表示で文字化けが発生しないことを確認
- 既存機能に影響がないことを確認